### PR TITLE
Feature - Allow conversion of column names to lower case to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ dbt run-operation required_docs [--args "{'models': '<space_delimited_models>'}"
 ```
 **Note:** Run this command _after_ `dbt run`: only models that already exist in
 the warehouse can be validated for columns that are missing from the model `.yml`.
+By default, column names are assumed to be lower case in the DBT documentation,
+if this is not the case in your project, setting the variable
+`convert_column_names_to_lower_case` to `false` in `dbt_project.yml` will
+compare the column names in the case they appear.
 
 ## Contributions
 Feedback on this project is welcomed and encouraged. Please open an issue or

--- a/macros/utils/required_docs/evaluate_required_docs.sql
+++ b/macros/utils/required_docs/evaluate_required_docs.sql
@@ -28,7 +28,7 @@
 
             {% for column in model_columns %}
 
-                {% if var("convert_column_names_to_lower_case", true) is true %}
+                {% if var("convert_column_names_to_lower_case", true) %}
                     {% set column = column | lower %}
                 {% endif %}
 

--- a/macros/utils/required_docs/evaluate_required_docs.sql
+++ b/macros/utils/required_docs/evaluate_required_docs.sql
@@ -28,7 +28,9 @@
 
             {% for column in model_columns %}
 
-                {% set column = column | lower %}
+                {% if var("convert_column_names_to_lower_case", true) is true %}
+                    {% set column = column | lower %}
+                {% endif %}
 
                 {% if column in model.columns.keys() %}
 


### PR DESCRIPTION
Hey, this probably isn't the best way to do this, just wanted to get your thoughts on having it as optional? We use caps for our col names (force of habit from Snowflake), and issue #1 seems to be similar?

Happy to change this/ completely re-write as preferred, just lmk 😸 