### PR TITLE
Fix - yaml invalid string

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,13 +245,13 @@ subsitution in a dictionary representation.
 
 For example, to run only changed models using dbt's Slim CI feature:
 ```bash
-dbt run-operation required_tests --args "{'models':'$(dbt list -m state:modified --state <filepath>)'}"
+dbt run-operation required_tests --args '{models:$(dbt list -m state:modified --state <filepath>)}'
 ```
 
 Alternatively, a space
 delimited string of model names will work as well:
 ```bash
-dbt run-operation required_tests --args "{'models':'model1 model2 model3'}"
+dbt run-operation required_tests --args '{models: model1 model2 model3}'
 ```
 
 ### required_tests ([source](macros/required_tests.sql))
@@ -260,7 +260,7 @@ Validates that models meet the `+required_tests` configurations applied in
 
 Usage:
 ```
-dbt run-operation required_tests [--args "{'models': '<space_delimited_models>'}"]
+dbt run-operation required_tests [--args '{models: <space_delimited_models>}']
 ```
 
 ### required_docs ([source](macros/required_tests.sql))
@@ -270,7 +270,7 @@ Validates that models meet the `+required_docs` configurations applied in
 
 Usage:
 ```
-dbt run-operation required_docs [--args "{'models': '<space_delimited_models>'}"]
+dbt run-operation required_docs [--args '{models: <space_delimited_models>}']
 ```
 **Note:** Run this command _after_ `dbt run`: only models that already exist in
 the warehouse can be validated for columns that are missing from the model `.yml`.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ subsitution in a dictionary representation.
 
 For example, to run only changed models using dbt's Slim CI feature:
 ```bash
-dbt run-operation required_tests --args '{models:$(dbt list -m state:modified --state <filepath>)}'
+dbt run-operation required_tests --args '{models: $(dbt list -m state:modified --state <filepath>)}'
 ```
 
 Alternatively, a space


### PR DESCRIPTION
Hi,

I'm having an *error* when i try using the module and following the ReadMe. (dbt 1.3.0, tnightengale/dbt_meta_testing 0.3.6)
`dbt run-operation required_docs --args "{'models': '$(dbt list -m state:modified --state ../../config/)'}"`
Produce :
`09:27:48  Running with dbt=1.3.0`
`09:27:48  The YAML provided in the --vars argument is not valid.`
`09:27:48  Encountered an error while running operation: Runtime Error   unacceptable character #x001b: special characters are not allowed     in "<unicode string>", position 12`

*I think the right way of calling it is*, based on what i understand from the [dbt doc](https://docs.getdbt.com/reference/commands/run-operation)  is :
`dbt run-operation required_docs --args '{models: $(dbt list -m state:modified --state ../../config/)}'`
And this time i get normal output
`09:27:06  Running with dbt=1.3.0`
`09:27:07  Checking required_docs config...`
`09:27:07  Success: required_docs passed.`
